### PR TITLE
search for street returns lowest housenumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ $ ./manage.py load_addresses (downloads adresses from WFS as geojson and saves t
 INSERT ADDRESSES
 $ ./manage.py insert_addresses --fromFixtures (inserts data from fixtures, for local development)
 $ ./manage.py insert_addresses (inserts all data from fixtures/addresses to database, might take a while, e.g. 30 minutes or more)
+$ ./manage.py insert_numberless_addresses --fromFixtures (inserts data from fixtures, for local development)
+$ ./manage.py insert_numberless_addresses (inserts all data from fixtures/addresses to database, might take a while, e.g. 2 minutes or more)
 
 ```
 here there is still an ugly error occurring twice that can be disregarded:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ $ ./manage.py insert_addresses --fromFixtures (inserts data from fixtures, for l
 $ ./manage.py insert_addresses (inserts all data from fixtures/addresses to database, might take a while, e.g. 30 minutes or more)
 $ ./manage.py insert_numberless_addresses --fromFixtures (inserts data from fixtures, for local development)
 $ ./manage.py insert_numberless_addresses (inserts all data from fixtures/addresses to database, might take a while, e.g. 2 minutes or more)
+$ ./manage.py insert_numberless_addresses --fromDatabase (inserts data based on database not files, might take a while e.g. 5 minutes or more)
 
 ```
 here there is still an ugly error occurring twice that can be disregarded:

--- a/bplan/management/commands/insert_addresses.py
+++ b/bplan/management/commands/insert_addresses.py
@@ -27,7 +27,6 @@ class Command(BaseCommand):
             strname += "asse"
         elif strname[-4:] == 'str.':
             strname = strname[:-1] + "asse"
-        hsnr = hsnr.lstrip('0')
         return (strname+hsnr).lower()
 
     def add_arguments(self, parser):

--- a/bplan/management/commands/insert_numberless_addresses.py
+++ b/bplan/management/commands/insert_numberless_addresses.py
@@ -1,0 +1,104 @@
+import os
+import json
+
+from tqdm import tqdm
+
+from django.utils.text import slugify
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from django.contrib.gis.gdal import DataSource
+from django.contrib.gis.geos import GEOSGeometry
+from django.contrib.gis.geos import Point
+
+from bplan.models import Address
+from bplan.models import Bezirk
+
+
+class Command(BaseCommand):
+
+    def _get_bezirk(self, point):
+        bezirk = Bezirk.objects.get(
+            polygon__intersects=point)
+        return bezirk
+
+    def _get_int(self, string):
+        while not string[-1].isdigit():
+            string = string[0:-1]
+        return int(string)
+
+    def _get_search_name(self, strname, hsnr):
+        strname = strname.replace(' ', '').replace('-', '').replace('ß', 'ss')
+        if strname[-3:] == 'str':
+            strname += "asse"
+        elif strname[-4:] == 'str.':
+            strname = strname[:-1] + "asse"
+        return (strname+hsnr).lower()
+
+    def _get_string(self, string):
+        while string[-1].isdigit():
+            string = string[0:-1]
+        return string
+
+    def add_arguments(self, parser):
+
+        parser.add_argument('--fromFixtures',
+                            action='store_true',
+                            dest='fromFixtures',
+                            default=False,
+                            help='Load data from fixtures')
+
+    def handle(self, *args, **options):
+
+        if options['fromFixtures']:
+            fixtures_dir = os.path.join(
+                settings.BASE_DIR, 'bplan', 'fixtures')
+        else:
+            fixtures_dir = os.path.join(
+                settings.BASE_DIR, 'bplan', 'fixtures', 'addresses')
+
+        filelist = os.listdir(fixtures_dir)
+        lowest_hsnrs = {}
+        lowest_hsnr_features = {}
+
+        for file in filelist:
+
+            filepath = os.path.join(fixtures_dir, file)
+
+            if not os.path.isdir(filepath) and file.startswith('addresses'):
+
+                data_source = DataSource(filepath)
+
+                for feature in tqdm(data_source[0]):
+                    point = GEOSGeometry(str(feature.geom), srid=4326)
+                    strname = feature.get("strname") + feature.get("plz")
+                    hsnr = (feature.get("hsnr")).lstrip('0')
+                    if not strname in lowest_hsnrs or \
+                        self._get_int(lowest_hsnrs[strname]) > self._get_int(hsnr):
+                        lowest_hsnrs[strname] = hsnr
+                        lowest_hsnr_features[strname] = feature
+
+        for street in lowest_hsnr_features:
+            feature = lowest_hsnr_features[street]
+            try:
+                point = GEOSGeometry(str(feature.geom), srid=4326)
+                strname = feature.get("strname")
+                hsnr = (feature.get("hsnr")).lstrip('0')
+                search_name = self._get_search_name(
+                    self._get_string(strname), '').rstrip(' ')
+                plz = feature.get("plz")
+                gml_id = feature.get("gml_id")
+                spatial_name = feature.get("spatial_name")
+                bezirk = self._get_bezirk(point)
+
+                address, created = Address.objects.get_or_create(
+                    point=point,
+                    strname=strname,
+                    search_name=search_name,
+                    hsnr='',
+                    plz=plz,
+                    gml_id=gml_id,
+                    spatial_name=spatial_name,
+                    bezirk=bezirk)
+            except Exception as e:
+                print(strname + ' ' + hsnr)
+                print(e)

--- a/bplan/static/js/app/shared/controllers/viewController.js
+++ b/bplan/static/js/app/shared/controllers/viewController.js
@@ -53,7 +53,6 @@ angular.module('app.shared.controllers.viewController', [])
 
     $scope.getDataForSearch = function() {
         $scope.places.getCoordintesForAdress($scope.searchstring).then(function(result) {
-            $scope.noHouseNumber = !$scope.searchstring.match(/\w+\ \d+\D?/g);
             $scope.addressSearchResult = result.features;
 
             $scope.places.getBplaeneForSearch($scope.searchstring).then(function(result) {

--- a/bplan/static/js/app/shared/directives/nav.html
+++ b/bplan/static/js/app/shared/directives/nav.html
@@ -42,7 +42,7 @@
                 <a href="" data-ng-click="chooseAddress(address)">
                     <div>
                     <i class="fa fa-map-marker" aria-hidden="true"></i>
-                    {{ address.properties.strname }} {{ address.properties.hsnr }},
+                    {{ address.properties.strname }}<span data-ng-if="address.properties.hsnr.length > 0"> {{ address.properties.hsnr }}</span>,
                     </div>
                     <div><small>{{ address.properties.bezirk_name }},  {{ address.properties.plz }} Berlin</small></div>
                 </a>

--- a/bplan/static/js/app/shared/directives/nav.html
+++ b/bplan/static/js/app/shared/directives/nav.html
@@ -35,7 +35,7 @@
                 </span>
             </div>
         </form>
-        <span data-ng-if="searchResultCount == 0" class="help-block">Es wurde kein Eintrag gefunden</span>
+        <span data-ng-if="searchResultCount == 0" class="help-block">Es wurde kein Eintrag gefunden.</span>
         <ul class="dropdown-menu">
             <li>Meinten Sie:</li>
             <li data-ng-repeat="address in addressSearchResult" class="address-search-result-item">

--- a/bplan/static/js/app/shared/directives/nav.html
+++ b/bplan/static/js/app/shared/directives/nav.html
@@ -35,8 +35,7 @@
                 </span>
             </div>
         </form>
-        <span data-ng-if="noHouseNumber" class="help-block">Bitte geben Sie eine Hausnummer an.</span>
-        <span data-ng-if="!noHouseNumber && searchResultCount == 0" class="help-block">Es wurde kein Eintrag gefunden.</span>
+        <span data-ng-if="searchResultCount == 0" class="help-block">Es wurde kein Eintrag gefunden</span>
         <ul class="dropdown-menu">
             <li>Meinten Sie:</li>
             <li data-ng-repeat="address in addressSearchResult" class="address-search-result-item">


### PR DESCRIPTION
Fixes #20. Reverts #33 because it's not necessary anymore.

So, now:
- searching for a street + a house number will give you all such available addresses - none if there are none. (These addresses, as before, get imported with `insert_addresses`.)
- searching for just a street will give you all such available streets - none if there are none. That's what `insert_numberless_addresses` does.

There's one small drawback about `insert_numberless_addresses`: right now, a street that crosses through multiple plz (post code) areas will return one search result per plz. Personally, I don't think that's very confusing.