### PR TITLE
Enable CORS for addresses api

### DIFF
--- a/bplan/api.py
+++ b/bplan/api.py
@@ -11,6 +11,7 @@ from .filters import AddressFilter
 from .filters import BezirkFilter
 from .filters import BPlanAddressFilter
 from .filters import BplanFilter
+from .filters import PlzFilter
 from .serializers import BezirkSerializer
 from .serializers import OrtsteilSerializer
 from .serializers import BPlanPointSerializer
@@ -47,7 +48,7 @@ class AddressViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = CustomAddressGeoJsonPagination
     serializer_class = AddressSerializer
     filter_backends = (
-        filters.DjangoFilterBackend, AddressFilter, BezirkFilter)
+        filters.DjangoFilterBackend, AddressFilter, BezirkFilter, PlzFilter)
 
 
 class BezirkViewSet(viewsets.ReadOnlyModelViewSet):

--- a/bplan/filters.py
+++ b/bplan/filters.py
@@ -37,10 +37,9 @@ class OrtsteilFilter(filters.BaseFilterBackend):
 
     def filter_queryset(self, request, queryset, view):
 
-        if 'ortsteil' in request.GET:
-            ortsteilslug = request.GET["ortsteil"]
-            ortsteil = Ortsteil.objects.get(slug=ortsteilslug)
-            return queryset.filter(ortsteile=ortsteil)
+        ortsteilslug = request.GET.get('ortsteil', None)
+        if ortsteilslug:
+            return queryset.filter(ortsteile__slug=ortsteilslug)
         else:
             return queryset
 
@@ -49,10 +48,9 @@ class BezirkFilter(filters.BaseFilterBackend):
 
     def filter_queryset(self, request, queryset, view):
 
-        if 'bezirk' in request.GET:
-            bezirksslug = request.GET["bezirk"]
-            bezirk = Bezirk.objects.get(slug=bezirksslug)
-            return queryset.filter(bezirk=bezirk)
+        bezirksslug = request.GET.get('bezirk', None)
+        if bezirksslug:
+            return queryset.filter(bezirk__slug=bezirksslug)
         else:
             return queryset
 

--- a/bplan/filters.py
+++ b/bplan/filters.py
@@ -55,6 +55,15 @@ class BezirkFilter(filters.BaseFilterBackend):
             return queryset
 
 
+class PlzFilter(filters.BaseFilterBackend):
+
+    def filter_queryset(self, request, queryset, view):
+        plz = request.GET.get('plz', None)
+        if plz:
+            return queryset.filter(plz=plz)
+        return queryset
+
+
 class AddressFilter(filters.BaseFilterBackend):
 
     def filter_queryset(self, request, queryset, view):

--- a/django_zbp/settings/base.py
+++ b/django_zbp/settings/base.py
@@ -44,11 +44,13 @@ INSTALLED_APPS = [
     'bplan',
     'compressor',
     #'debug_toolbar',
+    'corsheaders',
 ]
 
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
@@ -154,3 +156,7 @@ BOWER_INSTALLED_APPS = (
     'angular-loading-bar#0.9.0',
     'angular-animate#1.6.4'
 )
+
+# Allow Cross-Origin Resource Sharing only for address lookups
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_URLS_REGEX = r'^/api/addresses/.*$'

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ rjsmin==1.0.12
 six==1.10.0
 sqlparse==0.1.19
 tqdm==3.8.0
+django-cors-headers==2.0.0


### PR DESCRIPTION
As proposed by http://www.django-rest-framework.org/topics/ajax-csrf-cors/#cors the [django-cors-headers package](https://github.com/ottoyiu/django-cors-headers/) is used to allow requests from *any* origin for the `/api/addresses/` route.

Furthermore  the Bezirk and OrtsteilFilter have been fixed for the case if no Bezirk or Ortsteil is found. This raised an NotFoundException which resulted in a ServerError (500).

Also an optional Plz Filter was added to address lookups