### PR TITLE
Update psycopg2 so it works with psql 10.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ django-libsass==0.6
 djangorestframework==3.3.3
 djangorestframework-gis==0.10.1
 libsass==0.11.0
-psycopg2==2.6.1
+psycopg2==2.7.4
 python-dateutil==2.5.0
 pytz==2016.1
 rcssmin==1.0.6


### PR DESCRIPTION
This is required to make it build on ubuntu 18.04/the new server