### PR TITLE
bplan/management: Delete all BPlans before adding the loaded ones

### DIFF
--- a/bplan/management/commands/load_bplan.py
+++ b/bplan/management/commands/load_bplan.py
@@ -286,6 +286,9 @@ class Command(BaseCommand):
 
         download = Download.objects.create()
 
+        if data_source:
+            BPlan.objects.all().delete()
+
         errors = []
         points = []
 


### PR DESCRIPTION
to not keep the ones that were deleted in FIS Broker