### PR TITLE
info link: add new infor link to a meinberlin page

### DIFF
--- a/bplan/assets/js/app/shared/directives/nav.html
+++ b/bplan/assets/js/app/shared/directives/nav.html
@@ -137,7 +137,7 @@
         </ul>
     </li>
     <li role="presentation" class="info-button">
-        <a href="/static/information.html" target="_blank" aria-label="Allgemeine Informationen">
+        <a href="https://mein.berlin.de/b-plan-karte-hilfe/" target="_blank" aria-label="Allgemeine Informationen">
             <span class="fa-stack fa-lg" aria-hidden="true">
                 <i class="fa fa-circle-thin fa-stack-2x"></i>
                 <i class="fa fa-info fa-stack-1x"></i>


### PR DESCRIPTION
I assume this needs the full link because this page is not hosted on meinBerlin, but will mean that on dev it will still point to live page, is that ok? I'm just a bit confused because Caro mentions that she has added the page to dev in Taiga?!