### PR TITLE
bplan/management: Update API URL

### DIFF
--- a/bplan/management/commands/load_bplan.py
+++ b/bplan/management/commands/load_bplan.py
@@ -274,7 +274,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
 
         url = 'http://fbinter.stadt-berlin.de/fb/'\
-            'wfs/geometry/senstadt/re_bplan'
+            'wfs/data/senstadt/sach_bplan'
 
         if options['fromFixtures']:
             fixtures_dir = os.path.join(settings.BASE_DIR, 'bplan', 'fixtures')


### PR DESCRIPTION
```
bei unserem WFS auf die Geltungsbereiche der Bebauungspläne hat sich die Rechneradresse
geändert von https://fbinter.stadt-berlin.de/fb/wfs/geometry/senstadt/re_bplan auf die
neue Adresse https://fbinter.stadt-berlin.de/fb/wfs/data/senstadt/sach_bplan
```