### PR TITLE
requirements.txt: upgrade to sentry-sdk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ sqlparse==0.4.1
 tqdm==4.61.2
 whitenoise==5.2.0
 brotli==1.0.9
-raven==6.10.0
+sentry-sdk==1.2.0


### PR DESCRIPTION
move to the newer sentry-sdk as raven has been deprecated for a while now.